### PR TITLE
Refactor Interfaces

### DIFF
--- a/src/app/live/LiveSettings.tsx
+++ b/src/app/live/LiveSettings.tsx
@@ -1,7 +1,7 @@
 import { liveIndexer } from '@/lib/live/indexer'
 import PathSetting from 'ui/PathSetting'
 
-export default function LiveSettings() {  
+export default function LiveSettings() {
   const paths = liveIndexer.paths
 
   return (

--- a/src/app/live/LiveSettings.tsx
+++ b/src/app/live/LiveSettings.tsx
@@ -1,7 +1,7 @@
 import { liveIndexer } from '@/lib/live/indexer'
-import PathSetting from './PathSetting'
+import PathSetting from 'ui/PathSetting'
 
-export default function LiveSettings() {
+export default function LiveSettings() {  
   const paths = liveIndexer.paths
 
   return (
@@ -14,9 +14,9 @@ export default function LiveSettings() {
           Paths
         </span>
         {/* - Live root path */}
-        <PathSetting label='Live Root' value={paths.liveRoot} />
+        <PathSetting label='Live Root' value={paths.root} />
         {/* - Projects root path */}
-        <PathSetting label='Projects Root' value={paths.projectsRoot} />
+        <PathSetting label='Projects Root' value={paths.projects} />
         {/* - User Library root path */}
         <PathSetting label='User Library Root' value={paths.userLibrary} />
       </section>

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -2,17 +2,19 @@ import { liveIndexer } from '@/lib/live/indexer'
 import { LiveIndex } from '@/types/live'
 import IndexList from 'ui/IndexList'
 
-async function getIndex() {
-  return await liveIndexer.initializeIndex()
+async function initIndex() {
+  await liveIndexer.createIndex()
+  return liveIndexer.getIndex()
 }
 
 async function getProjects(index: LiveIndex) {
-  const projects = index.data.projects
-  return projects
+  return index.data.projects
 }
 
 export default async function Live() {
-  const index = await getIndex()
+  const index = await initIndex()
+  console.log(`[Live] index:`, index)
+
   const projects = await getProjects(index)
   console.log(`[Live] projects:`, projects.length)
 

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -1,35 +1,33 @@
 import { liveIndexer } from '@/lib/live/indexer'
-import { LiveIndex } from '@/types/live'
 import IndexList from 'ui/IndexList'
 
 async function initIndex() {
-  await liveIndexer.createIndex()
-  return liveIndexer.getIndex()
-}
-
-async function getProjects(index: LiveIndex) {
-  return index.data.projects
+  let index = liveIndexer.index
+  if (!index) {
+    index = await liveIndexer.createIndex()
+  }
+  return index
 }
 
 export default async function Live() {
-  const index = await initIndex()
-  console.log(`[Live] index:`, index)
+  let index = await initIndex()
 
-  const projects = await getProjects(index)
-  console.log(`[Live] projects:`, projects.length)
+  const projects = index.data.projects
+  // console.log(`[Live] projects:`, projects.length)
 
   return (
     <main className='min-h-screen p-8 flex flex-col'>
       <h1 className='mb-8 text-3xl font-bold'>Live</h1>
+      <span className='text-lg'>Projects: { projects.length }</span>
       <IndexList />
       <div className='flex flex-col gap-4 justify-between'>
         {
           projects.map((project, index) => (
-            <div key={index} className='p-4 border border-neutral-800 rounded'>
-              <h2 className='text-lg font-bold'>{project.name}</h2>
+            <div key={index} className='p-4 flex flex-row justify-between items-center border border-neutral-800 rounded'>
+              <h2 className='text-xl font-bold basis-2/5'>{project.name}</h2>
               <span className='text-xs'>{project.id}</span>
-              <span>{project.createdAt.toLocaleDateString()}</span>
-              <span>{project.modifiedAt.toLocaleDateString()}</span>
+              <span>C: {project.createdAt.toLocaleDateString()}</span>
+              <span>M: {project.modifiedAt.toLocaleDateString()}</span>
             </div>
           ))
         }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import LiveSettings from './LiveSettings'
+import LiveSettings from '../app/live/LiveSettings'
 
 export default function Settings() {
   return (

--- a/src/lib/live/indexer.ts
+++ b/src/lib/live/indexer.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { readdir, stat } from 'fs/promises'
-import { Indexer, IndexEntity, IndexingStrategy } from '@/types'
+import type { Indexer, IndexEntity, IndexingStrategy, Index } from '@/types'
 import { LiveFileExtension, LiveIndex, LiveProject } from '@/types/live'
 
 // User directory paths
@@ -11,7 +11,7 @@ const LIVE_USER_LIBRARY_ROOT_PATH = process.env.LIVE_USER_LIBRARY_ROOT_PATH ?? '
 /**
  * Ableton Live Indexer
  */
-class LiveIndexer implements Indexer {
+class LiveIndexer implements Indexer<LiveProject[]> {
 
   readonly FILE_EXTENSIONS: {
     LIVE_SET: string
@@ -22,7 +22,7 @@ class LiveIndexer implements Indexer {
     paths: { [key: string]: string }
   }
 
-  strategies: IndexingStrategy[] = []
+  strategies: IndexingStrategy<any>[] = []
 
   index: LiveIndex | null = null
 
@@ -64,8 +64,8 @@ class LiveIndexer implements Indexer {
    * Build the `LiveIndex`.
    * @returns Promise<LiveIndex>
    */
-  async buildIndex(): Promise<void> {
-    console.log(`[LiveIndexer buildIndex] Building index...`)
+  async createIndex(): Promise<void> {
+    console.log(`[LiveIndexer createIndex] Creating index...`)
     const projects = await this.getProjects()
 
     // TEMP: Random 10 digit number
@@ -85,6 +85,10 @@ class LiveIndexer implements Indexer {
         projects: projects
       }
     } as LiveIndex
+  }
+
+  getIndex(): LiveIndex {
+    return this.index as LiveIndex
   }
 
   async getIndexValue(key: string): Promise<IndexEntity[] | undefined> {
@@ -167,4 +171,4 @@ export const liveIndexer = new LiveIndexer(
   LIVE_USER_LIBRARY_ROOT_PATH
 )
 
-export default LiveIndexer
+// export default LiveIndexer

--- a/src/lib/live/indexer.ts
+++ b/src/lib/live/indexer.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { readdir, stat } from 'fs/promises'
-import { BaseIndexer } from '@/types'
+import { Indexer } from '@/types'
 import {
   LiveFileExtension,
   LiveIndex,
@@ -15,7 +15,7 @@ const LIVE_USER_LIBRARY_ROOT_PATH = process.env.LIVE_USER_LIBRARY_ROOT_PATH ?? '
 /**
  * Ableton Live Indexer
  */
-class LiveIndexer implements BaseIndexer {
+class LiveIndexer implements Indexer {
   LIVE_SET_FILE_EXT = LiveFileExtension.Set
   LIVE_CLIP_FILE_EXT = LiveFileExtension.Clip
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-import type { PathLike } from 'fs'
-
 export interface IndexEntity {
   fileExtension: string
   id: string
@@ -22,7 +20,11 @@ export interface Index<T extends IndexEntity[]> {
 
 export interface IndexingStrategy<T extends IndexEntity> {
   fileExtension: string
-  index: (rootDirectory: PathLike) => Promise<T[]>
+  index: (rootDirectory: string) => Promise<T[]>
+}
+
+export interface IndexerStrategies<T extends IndexEntity> {
+  [key: string]: IndexingStrategy<T>
 }
 
 export interface Indexer<T extends IndexEntity[]> {
@@ -37,13 +39,15 @@ export interface Indexer<T extends IndexEntity[]> {
 
   index: Index<T> | null
 
-  strategies: IndexingStrategy<any>[]
+  // strategies: IndexingStrategy<any>[]
+  strategies: IndexerStrategies<IndexEntity>
 
+  // findIndexEntites: <T extends IndexEntity>(rootDirectory: PathLike) => Promise<T[]>
   createIndex: () => Promise<Index<T>>
   getIndex: () => Index<T>
   getIndexValue: (key: string) => Promise<IndexEntity[] | undefined>
   saveIndex: <T extends IndexEntity[]>(index: Index<T>) => Promise<void>
-  saveIndexJson: (path: string, output: any[]) => Promise<void> // TODO: Replace this any
+  saveIndexJson: (path: string, output: any[]) => Promise<void>
 }
 
 export interface IndexerDatabase {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,7 +39,7 @@ export interface Indexer<T extends IndexEntity[]> {
 
   strategies: IndexingStrategy<any>[]
 
-  createIndex: () => Promise<void>
+  createIndex: () => Promise<Index<T>>
   getIndex: () => Index<T>
   getIndexValue: (key: string) => Promise<IndexEntity[] | undefined>
   saveIndex: <T extends IndexEntity[]>(index: Index<T>) => Promise<void>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export interface IndexEntity {
+export type IndexEntity = {
   fileExtension: string
   id: string
   name: string
@@ -7,7 +7,7 @@ export interface IndexEntity {
   }
 }
 
-export interface Index<T extends IndexEntity[]> {
+export type Index<T extends IndexEntity[]> = {
   id: string
   name: string
   version: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,23 +1,43 @@
-export interface BaseEntity {
+export interface IndexEntity {
   id: string
   name: string
   data?: any
 }
 
-export interface BaseIndex {
+export interface Index {
   id: string
   name: string
   version: string
   createdAt: Date
   modifiedAt: Date
   data: {
-    [key: string]: BaseEntity[]
+    [key: string]: IndexEntity[]
   }
 }
 
-export interface BaseIndexer {
-  initializeIndex(): void
-  buildIndex(): void
-  saveIndex(index: BaseIndex): void
-  writeJson(path: string, output: any[]): void // TODO: Replace this any !!
+export interface Indexer {
+  readonly FILE_EXTENSIONS: { [key: string]: string }
+
+  config: {
+    paths: { [key: string]: string }
+  }
+
+  index: Index
+
+  buildIndex(): Promise<void>
+
+  getIndexValue(key: string): IndexEntity[]
+  
+  saveIndex(index: Index): Promise<void>
+  saveIndexJson(path: string, output: any[]): Promise<void> // TODO: Replace this any !!
+}
+
+export interface IndexerDatabase {
+  getIndex(id: string): Promise<Index>
+  getIndexValue(id: string, key: string): Promise<IndexEntity[]>
+
+  setIndex(index: Index): Promise<void>
+  setIndexValue(id: string, key: string, value: IndexEntity[]): Promise<void>
+
+  updateIndexValue(id: string, key: string, value: IndexEntity[]): Promise<void>
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,12 @@
+import type { PathLike } from 'fs'
+
 export interface IndexEntity {
+  fileExtension: string
   id: string
   name: string
-  data?: any
+  data?: {
+    [key: string]: any
+  }
 }
 
 export interface Index {
@@ -15,29 +20,35 @@ export interface Index {
   }
 }
 
+export interface IndexingStrategy {
+  fileExtension: string
+  index: (rootDirectory: PathLike) => Promise<IndexEntity[]>
+}
+
 export interface Indexer {
-  readonly FILE_EXTENSIONS: { [key: string]: string }
+  readonly FILE_EXTENSIONS: {
+    [key: string]: string
+  }
 
   config: {
     paths: { [key: string]: string }
+    [key: string]: any
   }
 
-  index: Index
+  index: Index | null
 
-  buildIndex(): Promise<void>
+  strategies: IndexingStrategy[]
 
-  getIndexValue(key: string): IndexEntity[]
-  
-  saveIndex(index: Index): Promise<void>
-  saveIndexJson(path: string, output: any[]): Promise<void> // TODO: Replace this any !!
+  buildIndex: () => Promise<void>
+  getIndexValue: (key: string) => Promise<IndexEntity[] | undefined>
+  saveIndex: <T>(index: Index) => Promise<void>
+  saveIndexJson: (path: string, output: any[]) => Promise<void> // TODO: Replace this any
 }
 
 export interface IndexerDatabase {
-  getIndex(id: string): Promise<Index>
-  getIndexValue(id: string, key: string): Promise<IndexEntity[]>
-
-  setIndex(index: Index): Promise<void>
-  setIndexValue(id: string, key: string, value: IndexEntity[]): Promise<void>
-
-  updateIndexValue(id: string, key: string, value: IndexEntity[]): Promise<void>
+  getIndex: (id: string) => Promise<Index>
+  getIndexValue: (id: string, key: string) => Promise<IndexEntity[]>
+  setIndex: (index: Index) => Promise<void>
+  setIndexValue: (id: string, key: string, value: IndexEntity[]) => Promise<void>
+  updateIndexValue: (id: string, key: string, value: IndexEntity[]) => Promise<void>
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,23 +9,23 @@ export interface IndexEntity {
   }
 }
 
-export interface Index {
+export interface Index<T extends IndexEntity[]> {
   id: string
   name: string
   version: string
   createdAt: Date
   modifiedAt: Date
   data: {
-    [key: string]: IndexEntity[]
+    [key: string]: T
   }
 }
 
-export interface IndexingStrategy {
+export interface IndexingStrategy<T extends IndexEntity> {
   fileExtension: string
-  index: (rootDirectory: PathLike) => Promise<IndexEntity[]>
+  index: (rootDirectory: PathLike) => Promise<T[]>
 }
 
-export interface Indexer {
+export interface Indexer<T extends IndexEntity[]> {
   readonly FILE_EXTENSIONS: {
     [key: string]: string
   }
@@ -35,20 +35,21 @@ export interface Indexer {
     [key: string]: any
   }
 
-  index: Index | null
+  index: Index<T> | null
 
-  strategies: IndexingStrategy[]
+  strategies: IndexingStrategy<any>[]
 
-  buildIndex: () => Promise<void>
+  createIndex: () => Promise<void>
+  getIndex: () => Index<T>
   getIndexValue: (key: string) => Promise<IndexEntity[] | undefined>
-  saveIndex: <T>(index: Index) => Promise<void>
+  saveIndex: <T extends IndexEntity[]>(index: Index<T>) => Promise<void>
   saveIndexJson: (path: string, output: any[]) => Promise<void> // TODO: Replace this any
 }
 
 export interface IndexerDatabase {
-  getIndex: (id: string) => Promise<Index>
+  getIndex: <T extends IndexEntity[]>(id: string) => Promise<Index<T>>
   getIndexValue: (id: string, key: string) => Promise<IndexEntity[]>
-  setIndex: (index: Index) => Promise<void>
+  setIndex: <T extends IndexEntity[]>(index: Index<T>) => Promise<void>
   setIndexValue: (id: string, key: string, value: IndexEntity[]) => Promise<void>
   updateIndexValue: (id: string, key: string, value: IndexEntity[]) => Promise<void>
 }

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -4,7 +4,7 @@ import type { IndexEntity, Index } from '.'
 // Ableton Live Index Types
 //
 
-export interface LiveIndex extends Index<LiveProject[]> {
+export type LiveIndex = Index<LiveProject[]> & {
   owner: string
   liveVersion: string
   data: {
@@ -16,11 +16,15 @@ export interface LiveIndex extends Index<LiveProject[]> {
 // Ableton Live Types
 //
 
-// Base interface for all Live entities
-export interface LiveEntity extends IndexEntity {}
+// Base type for all Live entities
+export type LiveEntity = IndexEntity & {
+  createdAt: Date
+  modifiedAt: Date
+  path: string
+}
 
 // Live files, directories, etc., stored within `Ableton` directory
-interface LiveData extends LiveEntity {
+type LiveData = {
   createdAt: Date
   modifiedAt: Date
   path: string
@@ -35,32 +39,32 @@ export enum LiveFileExtension {
   Sample = '.wav'
 }
 
-interface LiveFile extends LiveData {
+type LiveFile = LiveData & {
   type: LiveSet | LiveSample | LiveClip
-  extension: LiveFileExtension
+  fileExtension: LiveFileExtension
   data: any
 }
 
-interface LiveFolder extends LiveData {
+type LiveFolder = LiveData & {
   files?: LiveFile[]
 }
 
-export interface LiveProject extends LiveFolder {
+export type LiveProject = LiveEntity & LiveFolder & {
   description?: string
   tags?: string[]
   // sets: LiveSet[]
 }
 
-export interface LiveSet extends LiveData {
+export type LiveSet = LiveEntity & {
   desription?: string
   tags?: string[]
 }
 
-export interface LiveTemplate extends LiveSet {
+export type LiveTemplate = LiveSet & {
   version: string
 }
 
-export interface LiveTrack extends LiveEntity {
+export type LiveTrack = LiveEntity & {
   type: 'Group' | 'Audio' | 'Midi'
   clips?: LiveClip[]
   devices?: LiveDevice[]
@@ -68,7 +72,7 @@ export interface LiveTrack extends LiveEntity {
   tags?: string[]
 }
 
-export interface LiveSample extends LiveData {
+export type LiveSample = LiveData & {
   type: 'Processed' | 'Recorded'
   sampleRate: number
   bitDepth: number
@@ -76,33 +80,33 @@ export interface LiveSample extends LiveData {
   tags?: string[]
 }
 
-export interface LiveClip extends LiveData {
+export type LiveClip = LiveData & {
   type: 'Audio' | 'Midi'
 }
 
-export interface LiveGroove extends LiveEntity {}
+export type LiveGroove = LiveData & {}
 
-export interface LivePreset extends LiveEntity {
+export type LivePreset = LiveData & {
   type: 'Instrument' | 'AudioEffect' | 'MidiEffect'
 }
 
-export interface LiveDevice extends LiveEntity {
+export type LiveDevice = LiveData & {
   type: 'Instrument' | 'AudioEffect' | 'MidiEffect'
   // parameters: LiveParameter[]
 }
 
-export interface LiveParameter extends LiveEntity {
+export type LiveParameter = LiveData & {
   value: number
   min: number
   max: number
   automation: LiveAutomation[]
 }
 
-export interface LiveAutomation {
+export type LiveAutomation = {
   breakpoints: LiveBreakpoint[]
 }
 
-export interface LiveBreakpoint {
+export type LiveBreakpoint = {
   time: number
   value: number
 }

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -1,10 +1,10 @@
-import { BaseEntity, BaseIndex } from '.'
+import { IndexEntity, Index } from '.'
 
 //
 // Ableton Live Index Types
 //
 
-export interface LiveIndex extends BaseIndex {
+export interface LiveIndex extends Index {
   owner: string
   liveVersion: string
   data: {
@@ -17,7 +17,7 @@ export interface LiveIndex extends BaseIndex {
 //
 
 // Base interface for all Live entities
-export interface LiveEntity extends BaseEntity {}
+export interface LiveEntity extends IndexEntity {}
 
 // Live files, directories, etc., stored within `Ableton` directory
 interface LiveData extends LiveEntity {

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -1,10 +1,10 @@
-import { IndexEntity, Index } from '.'
+import type { IndexEntity, Index } from '.'
 
 //
 // Ableton Live Index Types
 //
 
-export interface LiveIndex extends Index {
+export interface LiveIndex extends Index<LiveProject[]> {
   owner: string
   liveVersion: string
   data: {


### PR DESCRIPTION
This branch refactors the base Index interfaces and types used across the app.

**Major changes:**
- Use TypeScript generics for better type safety and code reusability.
- Add `IndexingStrategy` interface, used for defining how `IndexEntity` objects of a given file extension are found in the file system.
- Update `LiveIndexer` to implement the new `Indexer` interface.